### PR TITLE
Add mixin placeholder-wrapper

### DIFF
--- a/mixins/_placeholder-wrapper.scss
+++ b/mixins/_placeholder-wrapper.scss
@@ -1,0 +1,49 @@
+// https://github.com/jsw0528/base.sass/blob/master/stylesheets/base.sass/mixins/_placeholder-wrapper.scss
+
+$anonymous-placeholders: ();
+
+@mixin placeholder-wrapper($name, $args...) {
+  $times: map-get($anonymous-placeholders, ($name, $args)) or 0;
+  $anonymous-placeholders: map-merge($anonymous-placeholders, (($name, $args): $times + 1)) !global;
+  $index: index($anonymous-placeholders, (($name, $args) ($times + 1)));
+
+  @if $times == 0 {
+    @at-root %-#{$name}-#{$index} {
+      @content;
+    }
+  }
+
+  @extend %-#{$name}-#{$index};
+}
+
+/*============================= Usage ===========================
+@mixin test($a, $b) {
+  @include placeholder-wrapper(test, $a, $b) {
+    a: $a;
+    b: $b;
+  }
+}
+
+.foo {
+  @include test(1, 1);
+}
+
+.bar {
+  @include test(1, 2);
+}
+
+.baz {
+  @include test(1, 1);
+}
+
+=============================== Output ==========================
+.foo, .baz {
+  a: 1;
+  b: 1;
+}
+
+.bar {
+  a: 1;
+  b: 2;
+}
+=================================================================*/


### PR DESCRIPTION
Placeholder Selector 的缺点，是在哪定义就在哪输出，这样很可能会踩到 CSS 优先级的坑。

用我这个 placeholder-wrapper 给你的 mixin 包一层，这样就融合了 Mixin 和 Placeholder Selector 两者的优点。
